### PR TITLE
Movidos os exemplos de cadastro de euiqpamentos e rede

### DIFF
--- a/resources/views/equipamentos/form.blade.php
+++ b/resources/views/equipamentos/form.blade.php
@@ -27,13 +27,12 @@
         hidden
     @endif >
     <label for="patrimonio">Patrimônio</label>
-    <input name="patrimonio" type="text" class="form-control" value="{{ $equipamento->patrimonio or old('patrimonio') }}"
+    <input name="patrimonio" type="text" class="form-control" value="{{ $equipamento->patrimonio or old('patrimonio') }}" placeholder="Ex: 001.586985"
         @if (isset($equipamento->id) and ($equipamento->naopatrimoniado === 1))
             required
         @elseif (((old('naopatrimoniado') == null) or (old('naopatrimoniado') == 1)) and (!isset($equipamento->id)))
             required
         @endif >
-    <small class="form-text text-muted">Ex: 001.586985</small>
 </div>
 
 <div class="form-group" id="sempatrimonio"
@@ -44,26 +43,23 @@
     @endif >
     <label for="descricaosempatrimonio">Descrição para não patrimoniados</label>
     <input name="descricaosempatrimonio" type="text" class="form-control"
-        value="{{ $equipamento->descricaosempatrimonio or old('descricaosempatrimonio') }}"
+        value="{{ $equipamento->descricaosempatrimonio or old('descricaosempatrimonio') }}" placeholder="Ex: Professor visitante Joãozinho"
         @if (isset($equipamento->id) and ($equipamento->naopatrimoniado === 0))
             required
         @elseif ((old('naopatrimoniado') != null) and (old('naopatrimoniado') == 0))
             required
         @endif >
-    <small class="form-text text-muted">Ex: Professor visitante Joãozinho</small>
 </div>
 
 <div class="form-group">
     <label for="macaddress">Mac Address</label>
-    <input type="text" class="form-control" id="macaddress" name="macaddress" 
+    <input type="text" class="form-control" id="macaddress" name="macaddress" placeholder="Ex: 00:45:8A:AA:90:88" 
            value="{{ $equipamento->macaddress or old('macaddress') }}">
-    <small class="form-text text-muted">Ex: 00:45:8A:AA:90:88</small>
 </div>
 
 <div class="form-group">
     <label for="local">Local</label>
-    <input type="text" class="form-control" id="local" name="local" value="{{ $equipamento->local or old('local') }}">
-    <small class="form-text text-muted">Ex: Sala 10</small>
+    <input type="text" class="form-control" id="local" name="local" value="{{ $equipamento->local or old('local') }}" placeholder="Ex: Sala 10">
 </div>
 
 <div class="form-group">
@@ -99,7 +95,7 @@
 <div class="form-group row">
     <label class="col-sm-2 col-form-label" for="ip">IP</label>
     <div class="col-sm-7">
-        <input type="text" class="form-control form-control-lg" id="ip" name="ip" value="{{ $equipamento->ip or old('ip')  }}">
+        <input type="text" class="form-control form-control-lg" id="ip" name="ip" value="{{ $equipamento->ip or old('ip')  }}" placeholder="Ex: 192.168.0.1">
     </div>
 </div>
 

--- a/resources/views/redes/form.blade.php
+++ b/resources/views/redes/form.blade.php
@@ -1,56 +1,47 @@
 <div class="form-group">
     <label for="nome">Nome</label>
-    <input type="text" class="form-control" name="nome" value="{{ $rede->nome or old('nome')  }}" required>
-    <small class="form-text text-muted">Ex: Departamento de Música</small>
+    <input type="text" class="form-control" name="nome" value="{{ $rede->nome or old('nome')  }}" placeholder="Ex: Departamento de Música" required>
 </div>
 
 <div class="form-group">
     <label for="iprede">IP Rede</label>
-    <input type="text" class="form-control" name="iprede" value="{{ $rede->iprede or old('iprede') }}" required>
-    <small class="form-text text-muted">Ex: 143.107.75.0</small>
+    <input type="text" class="form-control" name="iprede" value="{{ $rede->iprede or old('iprede') }}" placeholder="Ex: 143.107.75.0" required>
 </div>
 
 <div class="form-group">
     <label for="cidr">Cidr</label>
-    <input type="text" class="form-control" name="cidr" value="{{ $rede->cidr or old('cidr') }}" required>
-    <small class="form-text text-muted">Ex: 29</small>
+    <input type="text" class="form-control" name="cidr" value="{{ $rede->cidr or old('cidr') }}" placeholder="Ex: 29" required>
 </div>
 
 <div class="form-group">
     <label for="gateway">Gateway</label>
-    <input type="text" class="form-control" name="gateway" value="{{ $rede->gateway or old('gateway') }}" required>
-    <small class="form-text text-muted">Ex: 143.107.75.1</small>
+    <input type="text" class="form-control" name="gateway" value="{{ $rede->gateway or old('gateway') }}" placeholder="Ex: 143.107.75.1"required>
 </div>
 
 <div class="form-group">
     <label for="netbios">Netbios</label>
-    <input type="text" class="form-control" name="netbios" value="{{ $rede->netbios or old('netbios') }}">
-    <small class="form-text text-muted">Ex: ad.eca.usp.br</small>
+    <input type="text" class="form-control" name="netbios" value="{{ $rede->netbios or old('netbios') }}" placeholder="Ex: ad.eca.usp.br">
 </div>
 
 <div class="form-group">
     <label for="ntp">NTP</label>
-    <input type="text" class="form-control" name="ntp" value="{{ $rede->ntp or old('ntp') }}">
-    <small class="form-text text-muted">Ex: ntp.usp.br</small>
+    <input type="text" class="form-control" name="ntp" value="{{ $rede->ntp or old('ntp') }}" placeholder="Ex: ntp.usp.br">
 </div>
 
 
  <div class="form-group">
     <label for="vlan">VLAN</label>
-    <input type="text" class="form-control" name="vlan" value="{{ $rede->vlan or old('vlan') }}">
-    <small class="form-text text-muted">Ex: 1587</small>
+    <input type="text" class="form-control" name="vlan" value="{{ $rede->vlan or old('vlan') }}" placeholder="Ex: 1587">
 </div>
 
 <div class="form-group">
     <label for="dns">DNS</label>
-    <input type="text" class="form-control" name="dns" value="{{ $rede->dns or old('dns') }}">
-    <small class="form-text text-muted">Ex: 143.107.253.3, 143.107.253.5</small>
+    <input type="text" class="form-control" name="dns" value="{{ $rede->dns or old('dns') }}" placeholder="Ex: 143.107.253.3, 143.107.253.5">
 </div>
 
 <div class="form-group">
     <label for="ad_domain">Domain Active Directory</label>
-    <input type="text" class="form-control" name="ad_domain" value="{{ $rede->ad_domain or old('ad_domain') }}">
-    <small class="form-text text-muted">Ex: mydomain.usp.br</small>
+    <input type="text" class="form-control" name="ad_domain" value="{{ $rede->ad_domain or old('ad_domain') }}"placeholder="mydomain.usp.br">
 </div>
 
 <div class="form-group row">


### PR DESCRIPTION
Os exemplos foram alterados da posição logo embaixo do campo para o placeholder do campo. Fix #139 