### PR TITLE
env() para config()

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -42,9 +42,9 @@ class LoginController extends Controller
     
     public function redirectToProvider()
     {
-        if (\App::environment('local') && env('SENHAUNICA_OVERRIDE')) {
+        if (\App::environment('local') && config('copaco.senha_unica_override')) {
             # busca o usuário dev
-            $dev_user = env('DEVELOPER_ID');
+            $dev_user = config('copaco.developer_id');
 
             # Se não encontra, retorna 404
             $user = User::findOrFail($dev_user);

--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -15,7 +15,7 @@ class ConfigController extends Controller
     public function index()
     {
         $configs = Config::all();
-        $consumer_deploy_key = env('CONSUMER_DEPLOY_KEY');
+        $consumer_deploy_key = config('copaco.consumer_deploy_key');
         return view('config/index',compact('consumer_deploy_key','configs'));
     }
 

--- a/app/Http/Controllers/DhcpController.php
+++ b/app/Http/Controllers/DhcpController.php
@@ -23,7 +23,7 @@ class DhcpController extends Controller
 
     public function dhcpd(Request $request)
     {
-        if($request->consumer_deploy_key != env('CONSUMER_DEPLOY_KEY'))
+        if($request->consumer_deploy_key != config('copaco.consumer_deploy_key'))
         {
             return response('Unauthorized action.', 403);
         }

--- a/app/Http/Controllers/FreeradiusController.php
+++ b/app/Http/Controllers/FreeradiusController.php
@@ -28,8 +28,7 @@ class FreeradiusController extends Controller
 
     public function file(Request $request)
     {
-        if($request->consumer_deploy_key != env('CONSUMER_DEPLOY_KEY'))
-        {
+        if ($request->consumer_deploy_key != config('copaco.consumer_deploy_key')) {
             return response('Unauthorized action.', 403);
         }
         $file = $this->freeradius->file();
@@ -38,7 +37,7 @@ class FreeradiusController extends Controller
 
     public function sincronize(Request $request)
     {
-        if( getenv('FREERADIUS_HABILITAR') != 'True' ){
+        if (!config('copaco.freeradius_habilitar')) {
             $request->session()->flash('alert-warning', 'Freeradius não habilitado, nenhuma ação feita!');
             return redirect("/config");
         }

--- a/app/Http/Controllers/RedeController.php
+++ b/app/Http/Controllers/RedeController.php
@@ -82,7 +82,7 @@ class RedeController extends Controller
         $rede->save();
 
         // Salva rede no freeRadius
-        if( getenv('FREERADIUS_HABILITAR') == 'True' ){
+        if (config('copaco.freeradius_habilitar')) {
             $this->freeradius->cadastraOuAtualizaRede($rede);
         }
 
@@ -150,12 +150,12 @@ class RedeController extends Controller
         $rede->save();
 
         // Salva/update rede no freeRadius
-        if( getenv('FREERADIUS_HABILITAR') == 'True' ){
+        if (config('copaco.freeradius_habilitar')) {
             $this->freeradius->cadastraOuAtualizaRede($rede);
-        } 
+        }
 
         $request->session()->flash('alert-success', 'Rede atualizada com sucesso!');
-        return redirect()->route('redes.show',['id' =>$rede]);
+        return redirect()->route('redes.show', ['id' => $rede]);
     }
 
     /**
@@ -167,14 +167,14 @@ class RedeController extends Controller
     public function destroy(Rede $rede)
     {
         // deleta rede no freeRadius
-        if( getenv('FREERADIUS_HABILITAR') == 'True' ){
+        if (config('copaco.freeradius_habilitar')) {
             $this->freeradius->deletaRede($rede);
         } 
 
         // Desaloca os equipamentos dessa rede 
         foreach ($rede->equipamentos as $equipamento) {
             // deleta equipamentos no freeRadius
-            if( getenv('FREERADIUS_HABILITAR') == 'True' ){
+            if (config('copaco.freeradius_habilitar')) {
                 $this->freeradius->deletaEquipamento($equipamento);
             }
             $equipamento->ip = null;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,7 +18,7 @@ class AppServiceProvider extends ServiceProvider
         Schema::defaultStringLength(191);
         
         // força https na produção
-        if (env('APP_ENV') === 'production') {
+        if (\App::environment('production')) {
             \URL::forceScheme('https');
         }
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -35,13 +35,14 @@ class AuthServiceProvider extends ServiceProvider
 
         # admin 
         Gate::define('admin', function ($user) {
-            $admins_id = explode(',', trim(env('SUPERADMINS_IDS')));
-            $admins_senhaunica = explode(',', trim(env('SUPERADMINS_SENHAUNICA')));
-            $admins_ldap = explode(',', trim(env('SUPERADMINS_LDAP')));
+            $admins_id = explode(',', trim(config('copaco.superadmins_ids')));
+            $admins_senhaunica = explode(',', trim(config('copaco.superadmins_senhaunica')));
+            $admins_ldap = explode(',', trim(config('copaco.superadmins_ldap')));
 
-            return in_array($user->id, $admins_id) ||
-                                   in_array($user->username_senhaunica, $admins_senhaunica) ||
-                                   in_array($user->username_senhaunica, $admins_ldap);
+            return
+                in_array($user->id, $admins_id) ||
+                in_array($user->username_senhaunica, $admins_senhaunica) ||
+                in_array($user->username_senhaunica, $admins_ldap);
 
             //Auth::user()
             //$codpesAdmins = explode(',', trim(env('SUPERADMIN_IDS')));

--- a/app/Utils/Freeradius.php
+++ b/app/Utils/Freeradius.php
@@ -32,7 +32,7 @@ class Freeradius
                 }
             }
         }
-    
+
         $build .= "DEFAULT Framed-Protocol == PPP\n";
         $build .= "    Framed-Protocol = PPP,\n";
         $build .= "    Framed-Compression = Van-Jacobson-TCP-IP\n\n";
@@ -49,30 +49,29 @@ class Freeradius
 
     public function cadastraOuAtualizaRede($rede)
     {
-        $records = 
-            [
-                [$rede->id,'Tunnel-Type',':=','VLAN'],
-                [$rede->id,'Tunnel-Medium-Type',':=','IEEE-802'],
-                [$rede->id,'Tunnel-Private-Group-Id',':=',$rede->vlan]
-            ];
+        $records = [
+            [$rede->id, 'Tunnel-Type', ':=', 'VLAN'],
+            [$rede->id, 'Tunnel-Medium-Type', ':=', 'IEEE-802'],
+            [$rede->id, 'Tunnel-Private-Group-Id', ':=', $rede->vlan]
+        ];
 
-        foreach($records as $record) {
+        foreach ($records as $record) {
 
             $fields = [
                 'groupname' => $record[0],
                 'attribute' => $record[1],
-                'op'        => $record[2],
-                'value'     => $record[3]
+                'op' => $record[2],
+                'value' => $record[3]
             ];
 
-            $filter = [ 
-                'groupname' =>$rede->id,
-                'attribute' =>$record[1]
+            $filter = [
+                'groupname' => $rede->id,
+                'attribute' => $record[1]
             ];
 
             // first, check if this record exist before insert
             $check = DB::connection('freeradius')->table('radgroupreply')->select()->where($filter)->first();
-            if(is_null($check)){
+            if (is_null($check)) {
                 DB::connection('freeradius')->table('radgroupreply')->insert($fields);
             } else {
                 DB::connection('freeradius')->table('radgroupreply')->where($filter)->update($fields);
@@ -82,14 +81,14 @@ class Freeradius
 
     public function deletaRede($rede)
     {
-        $filter = [ 
-            'groupname' =>$rede->id,
+        $filter = [
+            'groupname' => $rede->id,
         ];
 
         DB::connection('freeradius')->table('radgroupreply')->where($filter)->delete();
     }
 
-    public function cadastraOuAtualizaEquipamento($equipamento,$mac_antigo = null)
+    public function cadastraOuAtualizaEquipamento($equipamento, $mac_antigo = null)
     {
         // Garante que a rede para esse equipamento também esteja cadastrada
         $this->cadastraOuAtualizaRede($equipamento->rede);
@@ -100,41 +99,41 @@ class Freeradius
 
         // 1. Popula tabela radusergroup
         $fields = [
-            'UserName'  => $equipamento->macaddress,
+            'UserName' => $equipamento->macaddress,
             'GroupName' => $equipamento->rede->id,
         ];
 
-        $filter = [ 
+        $filter = [
             'UserName' => $mac_antigo,
         ];
         
         // radusergroup: first, check if this record exist before insert
         $check = DB::connection('freeradius')->table('radusergroup')->select()->where($filter)->first();
-        
-        if(is_null($mac_antigo) || is_null($check)){
+
+        if (is_null($mac_antigo) || is_null($check)) {
             DB::connection('freeradius')->table('radusergroup')->insert($fields);
-        } else {               
+        } else {
             DB::connection('freeradius')->table('radusergroup')->where($filter)->update($fields);
         }
 
         // 2. popula tabela radcheck
 
         $fields = [
-            'UserName'  => $equipamento->macaddress,
+            'UserName' => $equipamento->macaddress,
             'Attribute' => 'Cleartext-Password',
-            'Value'     => $equipamento->macaddress,
-            'Op'        => ':=',
+            'Value' => $equipamento->macaddress,
+            'Op' => ':=',
         ];
 
-        $filter = [ 
+        $filter = [
             'UserName' => $mac_antigo,
         ];
 
         $check = DB::connection('freeradius')->table('radcheck')->select()->where($filter)->first();
-        
-        if(is_null($mac_antigo) || is_null($check)){
+
+        if (is_null($mac_antigo) || is_null($check)) {
             DB::connection('freeradius')->table('radcheck')->insert($fields);
-        } else {               
+        } else {
             DB::connection('freeradius')->table('radcheck')->where($filter)->update($fields);
         }
 
@@ -144,7 +143,7 @@ class Freeradius
     {
         // 1. deleta da tabela radusergroup
         $equipamento->macaddress = $this->formataMacAddr($equipamento->macaddress);
-        $filter = [ 
+        $filter = [
             'UserName' => $equipamento->macaddress,
         ];
         DB::connection('freeradius')->table('radusergroup')->where($filter)->delete();
@@ -155,11 +154,18 @@ class Freeradius
 
     public function formataMacAddr($macaddr)
     {
-        $macaddr = str_replace(':',env('FREERADIUS_MACADDR_SEPARATOR'),$macaddr);
-        if( env('FREERADIUS_MACADDR_CASE') == 'lower'){
-            $macaddr = strtolower($macaddr);
-        } else if ( env('FREERADIUS_MACADDR_CASE') == 'upper') {
+        $macaddr_separator = config('copaco.freeradius_macaddr_separator');
+        $macaddr_case = config('copaco.freeradius_macaddr_case');
+
+        // Adiciona o separador
+        $macaddr = str_replace(':', $macaddr_separator, $macaddr);
+
+        // UPPER ou lower?
+        if ($macaddr_case == 'upper') {
             $macaddr = strtoupper($macaddr);
+        } else {
+            // esse é o default no config/copaco
+            $macaddr = strtolower($macaddr);
         }
         return $macaddr;
     }

--- a/config/copaco.php
+++ b/config/copaco.php
@@ -10,5 +10,40 @@ return [
     | externas. Novas diretivas devem ser criadas aqui se a release do desenvolvedor
     | não provê um arquivo próprio de configuração
     |
-    */
-]
+ */
+
+    /*
+    |--------------------------------------------------------------------------
+    | Senha Única
+    |--------------------------------------------------------------------------
+    | TODO: DOCUMENTAR VARIÁVEIS
+ */
+
+    'senha_unica_key' => env('SENHAUNICA_KEY', false),
+    'senha_unica_secret' => env('SENHAUNICA_SECRET', false),
+    'senha_unica_callback_id' => env('SENHAUNICA_CALLBACK_ID', false),
+
+    # Ambiente de desenvolvimento
+    'senha_unica_override' => env('SENHAUNICA_OVERRIDE', false),
+    'developer_id' => env('DEVELOPER_ID'),
+
+    # Admins
+    'superadmins_ids' => env('SUPERADMINS_IDS'),
+    'super_admins_senha_unica' => env('SUPERADMINS_SENHAUNICA'),
+    'super_admins_ldap' => env('SUPERADMINS_LDAP'),
+    /*
+    |--------------------------------------------------------------------------
+    | DHCP e FreeRadius
+    |--------------------------------------------------------------------------
+    | consumer_deploy_key = parâmetro enviado para os servidores DHCP e FreeRadius
+     */
+    'consumer_deploy_key' => env('CONSUMER_DEPLOY_KEY', false),
+
+    'freeradius_habilitar' => env('FREERADIUS_HABILITAR', false),
+    'freeradius_host' => env('FREERADIUS_HOST', 'localhost'),
+    'freeradius_user' => env('FREERADIUS_USER'),
+    'freeradius_db' => env('FREERADIUS_DB'),
+    'freeradius_db' => env('FREERADIUS_PASSWD'),
+    'freeradius_macaddr_separator' => env('FREERADIUS_MACADDR_SEPARATOR', '-'),
+    'freeradius_macaddr_case' => env('FREERADIUS_MACADDR_CASE', 'lower')
+];

--- a/config/copaco.php
+++ b/config/copaco.php
@@ -36,6 +36,7 @@ return [
     | DHCP e FreeRadius
     |--------------------------------------------------------------------------
     | consumer_deploy_key = parâmetro enviado para os servidores DHCP e FreeRadius
+    | freeradius_macaddr_case = 'upper','lower'
      */
     'consumer_deploy_key' => env('CONSUMER_DEPLOY_KEY', false),
 

--- a/config/copaco.php
+++ b/config/copaco.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | USPdev Copaco - Arquivo Principal de Configuração
+    |--------------------------------------------------------------------------
+    |
+    | Este arquivo abriga as integrações com bibliotecas desenvolvidas pelo USPdev e bibliotecas
+    | externas. Novas diretivas devem ser criadas aqui se a release do desenvolvedor
+    | não provê um arquivo próprio de configuração
+    |
+    */
+]


### PR DESCRIPTION
- Criação do arquivo de configuração: `config/copaco.php` :cat: 
- Substituídas todas as chamadas `env()` para `config()` - Fixes #306  :shipit: 
- Pequenas refatorações e formatações para PSR :book: 