### PR TITLE
Agora a persistência é feita num método só.

### DIFF
--- a/app/Utils/NetworkOps.php
+++ b/app/Utils/NetworkOps.php
@@ -127,6 +127,6 @@ class NetworkOps
                 }
             }
         }
-        return ['rede'=>$rede_id, 'ip'=>$ip, 'danger' => utf8_encode($danger)];
+        return ['rede'=>$rede_id, 'ip'=>$ip, 'danger' => $danger];
     }
 }


### PR DESCRIPTION
Aproveitei para corrigir um bug com encoding que apareceu nos testes. Não há testes automatizados nesse commit, contudo, o comportamento foi verificado compatível nos seguintes casos:

1) Atualização do equipamento não reclama do MAC Address já estar cadastrado. Foi um merge das regras do store e do update.

2) Cadastros (fixo, ip, rede)
  * sem rede e sem IP devolve:  (0, NULL, NULL);
  * sem rede e com IP devolve:  (1, NULL, NULL);
  * com rede e sem IP devolve:  (0, alocado, rede escolhida);
  * com rede e com IP devolve:  (1, escolhido, rede escolhida);
  * com rede e com IP errado:   (1, NULL, NULL).

3) O restante é essencialmente um cut & paste do original.