### PR TITLE
A ordem dos parâmetros estava trocada.

### DIFF
--- a/app/Rules/PertenceRede.php
+++ b/app/Rules/PertenceRede.php
@@ -16,10 +16,10 @@ class PertenceRede implements Rule
      *
      * @return void
      */
-    public function __construct($iprede, $gateway, $cidr)
+    public function __construct($gateway, $iprede, $cidr)
     {
-        $this->iprede = $iprede;
         $this->gateway = $gateway;
+        $this->iprede = $iprede;
         $this->cidr = $cidr;
     }
 


### PR DESCRIPTION
A conta só funcionava em casos fortuitos. (o curioso é que os testes automatizados foram incapazes de pegar essa inconsistência)